### PR TITLE
Remove javascript layer.

### DIFF
--- a/init.el
+++ b/init.el
@@ -33,7 +33,6 @@ values."
    '(
      clojure
      graphviz
-     javascript
      csv
      python
      ;; ----------------------------------------------------------------


### PR DESCRIPTION
This change stops emacs from looking for [tern](https://github.com/ternjs/tern) by removing the javascript layer.