### PR TITLE
Add interactive functions to insert src blocks

### DIFF
--- a/useful.org
+++ b/useful.org
@@ -60,6 +60,7 @@
     (insert-src-block "elisp" "(el" "silent"))
 
   (defun elv ()
+    "Add an elisp src block that outputs the resulting value."
     (interactive)
     (insert-src-block "elisp" "(el" "value"))
 

--- a/useful.org
+++ b/useful.org
@@ -50,6 +50,7 @@
     (insert-src-block "elisp" "(el" "output"))
 
   (defun elr ()
+    "Add an elisp src block that outputs the result value unformatted."
     (interactive)
     (insert-src-block "elisp" "(el" "raw"))
 

--- a/useful.org
+++ b/useful.org
@@ -76,6 +76,7 @@
     (insert-src-block "elisp" "(el" "value"))
 
   (defun py ()
+    "Add a python src block."
     (interactive)
     (insert-src-block "python" "(py"))
 

--- a/useful.org
+++ b/useful.org
@@ -40,6 +40,10 @@
              (insert-src-block* lang look :results results-specifier)
              (insert-src-block* lang look)))
 
+  (defun dot (file)
+    (interactive"F")
+    (insert-src-block* "dot" "(dot" :file file ))
+
   (defun el ()
     "Add an elisp src block."
     (interactive)

--- a/useful.org
+++ b/useful.org
@@ -41,6 +41,7 @@
              (insert-src-block* lang look)))
 
   (defun dot (file)
+    "Add a dot src block."
     (interactive"F")
     (insert-src-block* "dot" "(dot" :file file ))
 

--- a/useful.org
+++ b/useful.org
@@ -19,6 +19,9 @@
                                 ("j" "journal" entry (file+datetree ,capture-file)
                                  "* %?\n%U\n" ,@standard-options)))
 
+   (defun args-to-string (args)
+          (mapconcat 'stringify args " "))
+
   (defun insert-src-block (lang look &optional results-specifier)
     (insert (format "#+begin_src %s%s\n\n#+end_src" lang
                     (if results-specifier

--- a/useful.org
+++ b/useful.org
@@ -36,19 +36,9 @@
     (insert "  "))
 
   (defun insert-src-block (lang look &optional results-specifier)
-    (insert (format "#+begin_src %s%s\n\n#+end_src" lang
-                    (if results-specifier
-                        (concat " :results " results-specifier)
-                      "")))
-    (forward-line -3)
-    (beginning-of-line)
-    (if (looking-at look)
-        (progn
-          (kill-line)
-          (delete-char 1)
-          (forward-line))
-      (forward-line 2))
-    (insert "  "))
+         (if results-specifier
+             (insert-src-block* lang look :results results-specifier)
+             (insert-src-block* lang look)))
 
   (defun el ()
     "Add an elisp src block."

--- a/useful.org
+++ b/useful.org
@@ -75,6 +75,7 @@
     (insert-src-block "sh" "(sh" "output"))
 
   (defun shs ()
+    "Add a sh src block that outputs nothing."
     (interactive)
     (insert-src-block "sh" "(sh" "silent"))
 

--- a/useful.org
+++ b/useful.org
@@ -70,6 +70,7 @@
     (insert-src-block "sh" "(sh"))
 
   (defun sho ()
+    "Add a sh src block that outputs what is printed."
     (interactive)
     (insert-src-block "sh" "(sh" "output"))
 

--- a/useful.org
+++ b/useful.org
@@ -35,6 +35,7 @@
     (insert "  "))
 
   (defun el ()
+    "Add an elisp src block."
     (interactive)
     (insert-src-block "elisp" "(el"))
 

--- a/useful.org
+++ b/useful.org
@@ -86,6 +86,7 @@
     (insert-src-block "python" "(pyr" "raw"))
 
   (defun pyp ()
+    "Add a python src block that outputs pretty-printed python."
     (interactive)
     (insert-src-block "python" "(pyp" "pp"))
 

--- a/useful.org
+++ b/useful.org
@@ -45,6 +45,7 @@
     (insert-src-block "elisp" "(el" "code"))
 
   (defun elo ()
+    "Add an elisp src block that outputs what the code prints."
     (interactive)
     (insert-src-block "elisp" "(el" "output"))
 

--- a/useful.org
+++ b/useful.org
@@ -55,6 +55,7 @@
     (insert-src-block "elisp" "(el" "raw"))
 
   (defun els ()
+    "Add an elisp src block that outputs nothing."
     (interactive)
     (insert-src-block "elisp" "(el" "silent"))
 

--- a/useful.org
+++ b/useful.org
@@ -65,6 +65,7 @@
     (insert-src-block "elisp" "(el" "value"))
 
   (defun sh ()
+    "Add a sh src block."
     (interactive)
     (insert-src-block "sh" "(sh"))
 

--- a/useful.org
+++ b/useful.org
@@ -91,6 +91,7 @@
     (insert-src-block "python" "(pyp" "pp"))
 
   (defun pyf ()
+    "Add a python src block that interprts the results as a filename."
     (interactive)
     (insert-src-block "python" "(pyf" "file"))
 

--- a/useful.org
+++ b/useful.org
@@ -80,6 +80,10 @@
     (interactive)
     (insert-src-block "python" "(py"))
 
+  (defun pyr ()
+    (interactive)
+    (insert-src-block "python" "(pyr" "raw"))
+
   (defun sh ()
     "Add a sh src block."
     (interactive)

--- a/useful.org
+++ b/useful.org
@@ -75,6 +75,10 @@
     (interactive)
     (insert-src-block "elisp" "(el" "value"))
 
+  (defun py ()
+    (interactive)
+    (insert-src-block "python" "(py"))
+
   (defun sh ()
     "Add a sh src block."
     (interactive)

--- a/useful.org
+++ b/useful.org
@@ -90,6 +90,10 @@
     (interactive)
     (insert-src-block "python" "(pyp" "pp"))
 
+  (defun pyf ()
+    (interactive)
+    (insert-src-block "python" "(pyf" "file"))
+
   (defun sh ()
     "Add a sh src block."
     (interactive)

--- a/useful.org
+++ b/useful.org
@@ -40,6 +40,7 @@
     (insert-src-block "elisp" "(el"))
 
   (defun elc ()
+    "Add an elisp src block that outputs code."
     (interactive)
     (insert-src-block "elisp" "(el" "code"))
 

--- a/useful.org
+++ b/useful.org
@@ -81,6 +81,7 @@
     (insert-src-block "python" "(py"))
 
   (defun pyr ()
+    "Add a python src block that outputs the result value unformatted."
     (interactive)
     (insert-src-block "python" "(pyr" "raw"))
 

--- a/useful.org
+++ b/useful.org
@@ -85,6 +85,10 @@
     (interactive)
     (insert-src-block "python" "(pyr" "raw"))
 
+  (defun pyp ()
+    (interactive)
+    (insert-src-block "python" "(pyp" "pp"))
+
   (defun sh ()
     "Add a sh src block."
     (interactive)

--- a/useful.org
+++ b/useful.org
@@ -22,6 +22,19 @@
    (defun args-to-string (args)
           (mapconcat 'stringify args " "))
 
+   (defun insert-src-block* (lang look &rest args)
+    (insert (format "#+begin_src %s %s\n\n#+end_src" lang
+                     (args-to-string args)))
+    (forward-line -3)
+    (beginning-of-line)
+    (if (looking-at look)
+        (progn
+          (kill-line)
+          (delete-char 1)
+          (forward-line))
+      (forward-line 2))
+    (insert "  "))
+
   (defun insert-src-block (lang look &optional results-specifier)
     (insert (format "#+begin_src %s%s\n\n#+end_src" lang
                     (if results-specifier


### PR DESCRIPTION
History: A lot of students don't like having to type out source blocks. To solve this, you added functions like (el) to speed the process. Students still had to type out (el) and then call C-x C-e to execute the call, so I made those functions interactive to make things easier. Students still had to type out the dot src block, so I made the functions necessary to speed things up. Since Discrete Math is moving to Python, I decided to add some other functions. Finally, it would be useful for students to know what each function does, so I added docstrings to each function.

Summary: This series of commits does the following:
- Add documentation for existing functions that add src blocks
- Add the `insert-src-block*` function to make it possible to add other options. This is necessary for dot blocks.
- Add and document the interactive `dot` function to easily insert dot source blocks. When called interactively, `dot` prompts for an output file. The user should specify where they want the output. If the user just hits enter, it will specify the current org file, so be careful!
- Add and document various functions to add python src blocks.

Note that the dot function does not specify the `:cmd` or `:cmdline` header arguments, but it is easy to make a new function to do that.